### PR TITLE
vue refactor (remove interval loading, fix prop definitions and use $ref and $emit event)

### DIFF
--- a/vuejs/GoogleReCaptchaV3.vue
+++ b/vuejs/GoogleReCaptchaV3.vue
@@ -37,16 +37,26 @@
         },
         methods: {
             init() {
-                if (!('grecaptcha' in window)) {
+                if (!document.getElementById('gRecaptchaScript')) {
 
-                    window.gRecaptchaOnLoad = this.render;
+                    window.gRecaptchaOnLoadCallbacks = [this.render];
+                    window.gRecaptchaOnLoad = function () {
+                        for (let i = 0; i < window.gRecaptchaOnLoadCallbacks.length; i++) {
+                            window.gRecaptchaOnLoadCallbacks[i]();
+                        }
+                        delete window.gRecaptchaOnLoadCallbacks;
+                        delete window.gRecaptchaOnLoad;
+                    };
 
                     let recaptchaScript = document.createElement('script');
                     recaptchaScript.setAttribute('src', 'https://www.google.com/recaptcha/api.js?render=explicit&onload=gRecaptchaOnLoad');
+                    recaptchaScript.setAttribute('id', 'gRecaptchaScript');
                     recaptchaScript.async = true;
                     recaptchaScript.defer = true;
                     document.head.appendChild(recaptchaScript);
 
+                } else if (!window.grecaptcha || !window.grecaptcha.render) {
+                    window.gRecaptchaOnLoadCallbacks.push(this.render);
                 } else {
                     this.render();
                 }

--- a/vuejs/GoogleReCaptchaV3.vue
+++ b/vuejs/GoogleReCaptchaV3.vue
@@ -1,88 +1,74 @@
 <template>
-    <div :id="elementId"
-    ></div>
+    <div :id="id"></div>
 </template>
 
 <script>
     export default {
         name: 'google-recaptcha-v3',
         props: {
+            action: {
+                type: String,
+                required: false,
+                default: 'validate_grecaptcha'
+            },
+            id: {
+                type: String,
+                required: false,
+                default: 'grecaptcha_container'
+            },
             siteKey: {
                 type: String,
-                required: true
-            },
-            elementId: {
-                type: String,
-                required: true
+                required: false, // set to true if you don't want to store the siteKey in this component
+                default: '' // set siteKey here if you want to store it in this component
             },
             inline: {
                 type: Boolean,
-                default: false
+                required: false,
+                default: false,
             },
-            action: {
-                type: String,
-                required: true
-            }
         },
         data() {
             return {
-                gAssignedId: null,
-                captchaReady: false,
-                renderedReady: false,
-                checkInterval: null,
-                checkIntervalRunCount: 0
+                captchaId: null,
             }
         },
-        created() {
-        },
-        computed: {},
         mounted() {
             this.init();
         },
-        watch: {
-            captchaReady: function (data) {
-                if (data) {
-                    clearInterval(this.checkInterval)
-                    this.render()
-                }
-            },
-            renderedReady: function (data) {
-                if (data) {
-                    clearInterval(this.checkInterval)
-                    this.execute()
-                }
-            },
-        },
         methods: {
-            execute() {
-                let action = this.action;
-                window.grecaptcha.ready(function () {
-                    grecaptcha.execute(this.gAssignedId, {
-                        action: action
-                    });
-                });
+            init() {
+                if (!('grecaptcha' in window)) {
+
+                    window.gRecaptchaOnLoad = this.render;
+
+                    let recaptchaScript = document.createElement('script');
+                    recaptchaScript.setAttribute('src', 'https://www.google.com/recaptcha/api.js?render=explicit&onload=gRecaptchaOnLoad');
+                    recaptchaScript.async = true;
+                    recaptchaScript.defer = true;
+                    document.head.appendChild(recaptchaScript);
+
+                } else {
+                    this.render();
+                }
             },
+
             render() {
-                this.gAssignedId = window.grecaptcha.render(this.elementId, {
+                this.captchaId = window.grecaptcha.render(this.id, {
                     sitekey: this.siteKey,
                     badge: this.inline === true ? 'inline' : '',
-                    size: 'invisible'
+                    size: 'invisible',
+                    'expired-callback': this.execute
                 });
-                this.renderedReady = true;
+
+                this.execute();
             },
-            init() {
-                this.checkInterval = setInterval(() => {
-                    this.checkIntervalRunCount++;
-                    if (window.grecaptcha && window.grecaptcha.hasOwnProperty('render')) {
-                        this.captchaReady = true
-                    } else {
-                        let recaptchaScript = document.createElement('script');
-                        recaptchaScript.setAttribute('src', 'https://www.google.com/recaptcha/api.js?render=explicit');
-                        document.head.appendChild(recaptchaScript);
-                        recaptchaScript.async = true;
-                        recaptchaScript.defer = true;
-                    }
-                }, 1000)
+
+            execute() {
+                window.grecaptcha.execute(this.captchaId, {
+                    action: this.action,
+                }).then((token) => {
+                    this.$emit('input', token);
+                });
             }
         }
     }


### PR DESCRIPTION
- Refactored the Vue component to load a lot faster (not using intervals anymore)
- Made it possible to bind the response token to a model, the Vue way.
    <google-recaptcha-v3 v-model="yourDataAttribute"></google-recaptcha-v3>
- Made all props optional with default values that can be configured on the component

Note: when using model binding you need to call execute() after each request to get a new token.
In your template:
```
 <google-recaptcha-v3 ref="captcha" v-model="grecaptcha"></google-recaptcha-v3>
````
In your script:
```
this.form.post('/post-url')
    .then(response => {
        this.$refs.captcha.execute();
    })
    .catch(exception => {
        this.$refs.captcha.execute();    
    });
```