### PR TITLE
Return promise when refreshing recaptcha token.

### DIFF
--- a/resources/views/googlerecaptchav3/template.blade.php
+++ b/resources/views/googlerecaptchav3/template.blade.php
@@ -58,10 +58,11 @@
 
 <script {!! $nonce !!}>
     function refreshReCaptchaV3(fieldId,action){
-        grecaptcha.reset(window['client'+fieldId]);
-        grecaptcha.ready(function () {
-            grecaptcha.execute(window['client'+fieldId], {
-                action: action
+        return new Promise(function (resolve, reject) {
+            grecaptcha.ready(function () {
+                grecaptcha.execute(window['client'+fieldId], {
+                    action: action
+                }).then(resolve);
             });
         });
     }


### PR DESCRIPTION
This PR returns a promise when calling the refreshReCaptchaV3 function, this enables use cases such as refreshing the token when a user submits a form to avoid token timeouts if a user has not filled out the form within two minutes of loading a page. Then once the token has been refreshed, you can be notified and resume the ajax form submission request.

I have also removed the rest function call as it is not needed and causes execution to take longer since it has to re-initialize the entire widget instead of just refreshing the token.