### PR TITLE
Only enable explicit rending if inline option is enabled.

### DIFF
--- a/resources/views/googlerecaptchav3/template.blade.php
+++ b/resources/views/googlerecaptchav3/template.blade.php
@@ -51,7 +51,7 @@
             @endforeach
         }
     </script>
-    <script id='gReCaptchaScript' src="{{$apiJsUrl}}?render=explicit&onload=onloadCallback"
+    <script id='gReCaptchaScript' src="{{$apiJsUrl}}?render={{$inline ? 'explicit' : $publicKey}}&onload=onloadCallback"
             defer
             async {!! $nonce !!}></script>
 @endif


### PR DESCRIPTION
fixes #67 

If explicit rendering is enabled when the inline option is not enabled, the badge will be rendered in the first position where a reCAPTCHA badge is rendered. By removing the explicit rendering option, the badge will be rendered in the bottom right of the page.