### PR TITLE
Hide reCAPTCHA badge using visibility css property.

### DIFF
--- a/resources/views/googlerecaptchav3/template.blade.php
+++ b/resources/views/googlerecaptchav3/template.blade.php
@@ -6,7 +6,7 @@
     @if($display === false)
         <style {!! $nonce !!}>
             .grecaptcha-badge {
-                display: none;
+                visibility: hidden;
             }
         </style>
     @endif


### PR DESCRIPTION
There have been reports hiding the badge using `display: none` can cause spam checking to be disabled, and according to the FAQs on reCAPTCHA's website they demonstrate hiding the badge using `visibility: hidden`.

https://stackoverflow.com/questions/44543157/how-to-hide-the-google-invisible-recaptcha-badge
https://developers.google.com/recaptcha/docs/faq#id-like-to-hide-the-recaptcha-badge.-what-is-allowed